### PR TITLE
clarify origin/destination are strings

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1774,7 +1774,7 @@ components:
         origin:
           type: string
           description: Routing Number - four digit Federal Reserve Routing Symbol and the four digit ABA Institution Identifier
-          example: 99991234
+          example: "99991234"
         originName:
           type: string
           description: Legal name associated with the origin routing number.
@@ -1782,7 +1782,7 @@ components:
         destination:
           type: string
           description: Routing Number - four digit Federal Reserve Routing Symbol and the four digit ABA Institution Identifier
-          example: 69100013
+          example: "69100013"
         destinationName:
           type: string
           description: Legal name associated with the destination routing number
@@ -2094,7 +2094,7 @@ components:
               origin:
                 type: string
                 description: Routing Number - four digit Federal Reserve Routing Symbol and the four digit ABA Institution Identifier
-                example: 99991234
+                example: "99991234"
               originName:
                 type: string
                 description: Legal name associated with the origin routing number.
@@ -2102,7 +2102,7 @@ components:
               destination:
                 type: string
                 description: Routing Number - four digit Federal Reserve Routing Symbol and the four digit ABA Institution Identifier
-                example: 69100013
+                example: "69100013"
               destinationName:
                 type: string
                 description: Legal name associated with the destination routing number


### PR DESCRIPTION
They show up as integers currently, which doesn't work for 0-prefixed values. 