### PR TITLE
cmd/apitest: support -local 

### DIFF
--- a/cmd/apitest/main.go
+++ b/cmd/apitest/main.go
@@ -32,6 +32,7 @@ var (
 	defaultApiAddress = "https://api.moov.io"
 
 	flagApiAddress = flag.String("address", defaultApiAddress, "Moov API address")
+	flagLocal      = flag.Bool("local", false, "Use local HTTP addresses")
 )
 
 func main() {
@@ -41,8 +42,20 @@ func main() {
 	ctx := context.TODO()
 
 	conf := moov.NewConfiguration()
-	conf.BasePath = *flagApiAddress
+	if *flagLocal {
+		// If '-local and -address <foo>' use <foo>
+		if addr := *flagApiAddress; addr != defaultApiAddress {
+			conf.BasePath = addr
+		} else {
+			conf.BasePath = "http://localhost"
+		}
+	} else {
+		conf.BasePath = *flagApiAddress
+	}
+	log.Printf("Using %s as base API address", conf.BasePath)
 	conf.UserAgent = fmt.Sprintf("apitest/%s", version.Version)
+
+	// setup HTTP client
 	conf.HTTPClient = &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
@@ -51,6 +64,12 @@ func main() {
 			MaxConnsPerHost:     100,
 			IdleConnTimeout:     1 * time.Minute,
 		},
+	}
+	if *flagLocal {
+		tr := conf.HTTPClient.Transport
+		conf.HTTPClient.Transport = &localPathTransport{
+			tr: tr,
+		}
 	}
 
 	requestId := generateID()
@@ -98,6 +117,6 @@ func pingApps(ctx context.Context, api *moov.APIClient) error {
 		return fmt.Errorf("ERROR: failed to ping paygate: %v", err)
 	}
 	resp.Body.Close()
-	log.Println("paygaate PONG")
+	log.Println("paygate PONG")
 	return nil
 }

--- a/cmd/apitest/transport.go
+++ b/cmd/apitest/transport.go
@@ -1,0 +1,53 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+var (
+	// localhostOverrides is a mapping of $app (from /v1/$app/* paths) to port.
+	localhostOverrides = map[string]string{
+		"ach":     "8080",
+		"auth":    "8081",
+		"paygate": "8082",
+		"x9":      "8083",
+	}
+)
+
+type localPathTransport struct {
+	tr http.RoundTripper
+}
+
+// RoundTrip modifies the incoming request to reshape a Moov API production URL to a local dev URL.
+// The GoDoc for http.RoundTripper state that the request SHOULD not be modified, not MUST. If this
+// ends up causing problems we'll have to figure out another solution.
+//
+// This means:
+//  - Dropping /v1/$app routing prefix
+//  - Changing the local port used (each app runs on its own port now)
+//    - Adjusting the scheme if needed.
+func (t *localPathTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Each route looks like /v1/$app/... so we need to trim off the v1 and $app segments
+	// while looking up $app's port mapping.
+	parts := strings.Split(r.URL.Path, "/")
+
+	if len(parts) < 3 { // parts splits into: "", v1, $app, (rest of url)
+		// Pass through whatever this request is.
+		return t.tr.RoundTrip(r)
+	}
+
+	if port, exists := localhostOverrides[parts[2]]; exists {
+		r.URL.Host = "localhost:" + port
+		r.URL.Scheme = "http"
+	}
+
+	// fixup our path now
+	r.URL.Path = "/" + strings.Join(parts[3:], "/") // everything after $app
+
+	return t.tr.RoundTrip(r)
+}

--- a/cmd/apitest/transport_test.go
+++ b/cmd/apitest/transport_test.go
@@ -1,0 +1,33 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLocalPathTransport(t *testing.T) {
+	r := httptest.NewRequest("GET", "https://api.moov.io/v1/ach/files/fileId", nil)
+	tr := &localPathTransport{
+		tr: &http.Transport{},
+	}
+
+	resp, err := tr.RoundTrip(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Request.URL.Path != "/files/fileId" {
+		t.Errorf("got %s", resp.Request.URL.Path)
+	}
+	if resp.Request.URL.Host != "localhost:8080" {
+		t.Errorf("got %s", resp.Request.URL.Host)
+	}
+	if resp.Request.URL.Scheme != "http" {
+		t.Errorf("got %s", resp.Request.URL.Scheme)
+	}
+}


### PR DESCRIPTION
`-local` is a flag to point `apitest` (our API testing utility) against local app instances. This uses the new `bind.HTTP` helper.

```
$ go run ./cmd/apitest -local 
2018/10/30 16:28:22 Starting apitest v0.2.10-dev
2018/10/30 16:28:22 Using http://localhost as base API address
2018/10/30 16:28:22 Using X-Request-ID: e8a161718dd188a9af0ae7b0488e58bea40cede5
2018/10/30 16:28:22 ACH PONG
2018/10/30 16:28:22 auth PONG
2018/10/30 16:28:22 paygate PONG
```

Fixes: https://github.com/moov-io/api/issues/25 