### PR TITLE
cmd/apitest: Add -oauth flag to test OAuth access token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ script:
   - go test ./...
   - make build
   - docker run moov/apitest:latest
+  - docker run moov/apitest:latest -oauth

--- a/cmd/apitest/login.go
+++ b/cmd/apitest/login.go
@@ -17,14 +17,18 @@ import (
 	"github.com/antihax/optional"
 )
 
-// setMoovAuthHeaders adds authentication onto our Moov API client for all requests
-func setMoovAuthHeaders(conf *moov.Configuration, user *user) {
+// setMoovAuthCookie adds authentication onto our Moov API client for all requests
+func setMoovAuthCookie(conf *moov.Configuration, user *user) {
 	if user.Cookie.Value != "" {
 		conf.AddDefaultHeader("Cookie", fmt.Sprintf("moov_auth=%s", user.Cookie.Value))
 	} else {
 		log.Fatalf("no cookie found (userId: %v)", user.ID)
 	}
 	conf.AddDefaultHeader("X-User-Id", user.ID)
+}
+
+func removeMoovAuthCookie(conf *moov.Configuration) {
+	delete(conf.DefaultHeader, "Cookie")
 }
 
 // verifyUserIsLoggedIn takes the given moov.APIClient and checks if it's is logged in. A non-nil error signals

--- a/cmd/apitest/oauth.go
+++ b/cmd/apitest/oauth.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	moov "github.com/moov-io/go-client/client"
@@ -51,6 +52,8 @@ func (o OAuthToken) Expires() time.Duration {
 func setMoovOAuthToken(conf *moov.Configuration, oauthToken OAuthToken) {
 	if v := oauthToken.Access(); v != "" {
 		conf.AddDefaultHeader("Authorization", fmt.Sprintf("Bearer %s", v))
+	} else {
+		log.Fatal("FAILURE: No OAuth token provided")
 	}
 }
 

--- a/cmd/apitest/oauth.go
+++ b/cmd/apitest/oauth.go
@@ -48,6 +48,12 @@ func (o OAuthToken) Expires() time.Duration {
 	return dur
 }
 
+func setMoovOAuthToken(conf *moov.Configuration, oauthToken OAuthToken) {
+	if v := oauthToken.Access(); v != "" {
+		conf.AddDefaultHeader("Authorization", fmt.Sprintf("Bearer %s", v))
+	}
+}
+
 func createOAuthToken(ctx context.Context, api *moov.APIClient, u *user, requestId string) (OAuthToken, error) {
 	// Create OAuth client credentials
 	clients, resp, err := api.OAuth2Api.CreateOAuth2Client(ctx, &moov.CreateOAuth2ClientOpts{


### PR DESCRIPTION
`-oauth` drops the `Cookie` and only sets our OAuth `Bearer` token on requests. 

Fixes: https://github.com/moov-io/api/issues/53