### PR TITLE
api: remove Depository.Parent field

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1095,7 +1095,7 @@ paths:
     post:
       tags:
       - Depositories
-      summary: Create a new depository account for a Customer ID or Originator ID defined in the Parent parameter
+      summary: Create a new depository account for the authenticated user
       operationId: addDepository
       security:
         - bearerAuth: []
@@ -2374,10 +2374,6 @@ components:
           type: string
           description: Additional meta data to be used for display only
           example: Payroll
-        parent:
-          type: string
-          description: The depository owner's valid Customer ID or Originator ID
-          example: feb492e6
       required:
         - bankName
         - holder
@@ -2385,7 +2381,6 @@ components:
         - type
         - routingNumber
         - accountNumber
-        - parent
     Depository:
       properties:
         id:
@@ -2431,10 +2426,6 @@ components:
           type: string
           description: Additional meta data to be used for display only
           example: Payroll
-        parent:
-          type: string
-          description: The depository owner's valid Customer ID or Originator ID
-          example: feb492e6
         created:
           type: string
           format: date-time


### PR DESCRIPTION
> The depository owner's valid Customer ID or Originator ID

This field isn't needed as we store `user_id` on the sqlite table. That'll be used to search, not a field on the `Transfer` struct.