### PR TITLE
cmd/apitest/local: switch to less common port

### DIFF
--- a/cmd/apitest/local/transport_test.go
+++ b/cmd/apitest/local/transport_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func TestTransport(t *testing.T) {
-	r := httptest.NewRequest("GET", "https://api.moov.io/v1/ach/files/fileId", nil)
+	r := httptest.NewRequest("GET", "https://api.moov.io/v1/ach/transfers/foo", nil)
 	tr := &Transport{
 		Underlying: &http.Transport{},
 	}
 
 	svc := &http.Server{
-		Addr: ":8080",
+		Addr: ":8082",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("pong"))
 		}),
@@ -30,10 +30,10 @@ func TestTransport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if resp.Request.URL.Path != "/files/fileId" {
+	if resp.Request.URL.Path != "/transfers/foo" {
 		t.Errorf("got %s", resp.Request.URL.Path)
 	}
-	if resp.Request.URL.Host != "localhost:8080" {
+	if resp.Request.URL.Host != "localhost:8082" {
 		t.Errorf("got %s", resp.Request.URL.Host)
 	}
 	if resp.Request.URL.Scheme != "http" {


### PR DESCRIPTION
`:8080` might be bound already in the tests, so let's try `:8082` on TravisCI (where this test is failing).