### PR TITLE
cmd/apitest: close resp.Body's asap

### DIFF
--- a/cmd/apitest/gl.go
+++ b/cmd/apitest/gl.go
@@ -55,16 +55,14 @@ func createGLAccount(ctx context.Context, api *gl.APIClient, u *user, name, requ
 		Name: name,
 		Type: "Savings",
 	}, opts)
-
 	if *flagDebug {
 		log.Printf("GL create account request URL: %s (status=%s): %v\n", resp.Request.URL.String(), resp.Status, err)
 	}
-
-	if err != nil {
-		return nil, fmt.Errorf("problem creating GL account %s: %v", name, err)
-	}
 	if resp != nil {
 		resp.Body.Close()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("problem creating GL account %s: %v", name, err)
 	}
 	return &account, nil
 }

--- a/cmd/apitest/login.go
+++ b/cmd/apitest/login.go
@@ -37,14 +37,14 @@ func verifyUserIsLoggedIn(ctx context.Context, api *moov.APIClient, user *user, 
 	resp, err := api.UserApi.CheckUserLogin(ctx, &moov.CheckUserLoginOpts{
 		XRequestId: optional.NewString(requestId),
 	})
+	if resp != nil {
+		resp.Body.Close()
+	}
 	if err != nil {
 		return fmt.Errorf("problem checking user (id=%s) login: %v", user.ID, err)
 	}
-	if resp != nil {
-		if resp.StatusCode != 200 {
-			return fmt.Errorf("on cookie check, got %s status", resp.Status)
-		}
-		return resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("on cookie check, got %s status", resp.Status)
 	}
 	return nil
 }
@@ -58,10 +58,10 @@ func attemptFailedLogin(ctx context.Context, api *moov.APIClient, requestId stri
 		XIdempotencyKey: optional.NewString(generateID()),
 	})
 	if resp != nil {
+		resp.Body.Close()
 		if resp.StatusCode != http.StatusForbidden {
 			return fmt.Errorf("got %s response code", resp.Status)
 		}
-		defer resp.Body.Close()
 	}
 	if err == nil {
 		bs, err := ioutil.ReadAll(resp.Body)

--- a/cmd/apitest/oauth.go
+++ b/cmd/apitest/oauth.go
@@ -65,11 +65,11 @@ func createOAuthToken(ctx context.Context, api *moov.APIClient, u *user, request
 		XRequestId:      optional.NewString(requestId),
 		XIdempotencyKey: optional.NewString(generateID()),
 	})
+	if resp != nil {
+		resp.Body.Close()
+	}
 	if err != nil {
 		return nil, fmt.Errorf("problem creating user: %v", err)
-	}
-	if resp != nil {
-		defer resp.Body.Close()
 	}
 
 	if len(clients) == 0 {
@@ -85,11 +85,11 @@ func createOAuthToken(ctx context.Context, api *moov.APIClient, u *user, request
 		ClientId:        optional.NewString(client.ClientId),
 		ClientSecret:    optional.NewString(client.ClientSecret),
 	})
+	if resp != nil {
+		resp.Body.Close()
+	}
 	if err != nil {
 		return nil, fmt.Errorf("problem creating user: %v", err)
-	}
-	if resp != nil {
-		defer resp.Body.Close()
 	}
 
 	if len(tk) == 0 {
@@ -119,14 +119,12 @@ func attemptFailedOAuth2Login(ctx context.Context, api *moov.APIClient, requestI
 	resp, err := api.OAuth2Api.CheckOAuthClientCredentials(ctx, fmt.Sprintf("Bearer %s", token), &moov.CheckOAuthClientCredentialsOpts{
 		XRequestId: optional.NewString(requestId),
 	})
-
 	if resp != nil {
+		resp.Body.Close()
 		if resp.StatusCode != http.StatusForbidden {
 			return fmt.Errorf("got %s response code", resp.Status)
 		}
-		defer resp.Body.Close()
 	}
-
 	if err == nil {
 		bs, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -134,6 +132,5 @@ func attemptFailedOAuth2Login(ctx context.Context, api *moov.APIClient, requestI
 		}
 		return errors.New("expected error, but got nothing")
 	}
-
 	return nil
 }

--- a/cmd/apitest/signup.go
+++ b/cmd/apitest/signup.go
@@ -62,7 +62,7 @@ func createUser(ctx context.Context, api *moov.APIClient, requestId string) (*us
 		return nil, fmt.Errorf("problem creating user: %v", err)
 	}
 	if resp != nil {
-		defer resp.Body.Close()
+		resp.Body.Close()
 	}
 
 	// Now login
@@ -71,11 +71,11 @@ func createUser(ctx context.Context, api *moov.APIClient, requestId string) (*us
 		XRequestId:      optional.NewString(requestId),
 		XIdempotencyKey: optional.NewString(generateID()),
 	})
+	if resp != nil {
+		resp.Body.Close()
+	}
 	if err != nil {
 		return nil, fmt.Errorf("problem logging in for user: %v", err)
-	}
-	if resp != nil {
-		defer resp.Body.Close()
 	}
 	if u.CreatedAt.IsZero() {
 		return nil, fmt.Errorf("got zero time: %#v", u)

--- a/cmd/apitest/transfer.go
+++ b/cmd/apitest/transfer.go
@@ -37,11 +37,11 @@ func createDepository(ctx context.Context, api *moov.APIClient, u *user, account
 		XIdempotencyKey: optional.NewString(generateID()),
 		XRequestId:      optional.NewString(requestId),
 	})
-	if err != nil {
-		return dep, fmt.Errorf("problem creating depository (name: %q) for user (userId=%s): %v", account.Name, u.ID, err)
-	}
 	if resp != nil {
 		resp.Body.Close()
+	}
+	if err != nil {
+		return dep, fmt.Errorf("problem creating depository (name: %q) for user (userId=%s): %v", account.Name, u.ID, err)
 	}
 
 	// verify with (known, fixed values) micro-deposits
@@ -64,11 +64,11 @@ func verifyDepository(ctx context.Context, api *moov.APIClient, dep moov.Deposit
 		XIdempotencyKey: optional.NewString(generateID()),
 		XRequestId:      optional.NewString(requestId),
 	})
-	if err != nil {
-		return fmt.Errorf("problem starting micro deposits: %v", err)
-	}
 	if resp != nil {
 		resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("problem starting micro deposits: %v", err)
 	}
 
 	// confirm micro deposits
@@ -76,11 +76,11 @@ func verifyDepository(ctx context.Context, api *moov.APIClient, dep moov.Deposit
 		XIdempotencyKey: optional.NewString(generateID()),
 		XRequestId:      optional.NewString(requestId),
 	})
-	if err != nil {
-		return fmt.Errorf("problem verifying micro deposits: %v", err)
-	}
 	if resp != nil {
 		resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("problem verifying micro deposits: %v", err)
 	}
 	return nil
 }
@@ -95,11 +95,11 @@ func createOriginator(ctx context.Context, api *moov.APIClient, depId, requestId
 		XIdempotencyKey: optional.NewString(generateID()),
 		XRequestId:      optional.NewString(requestId),
 	})
-	if err != nil {
-		return orig, fmt.Errorf("problem creating originator: %v", err)
-	}
 	if resp != nil {
 		resp.Body.Close()
+	}
+	if err != nil {
+		return orig, fmt.Errorf("problem creating originator: %v", err)
 	}
 	return orig, nil
 }
@@ -114,11 +114,11 @@ func createCustomer(ctx context.Context, api *moov.APIClient, u *user, depId, re
 		XIdempotencyKey: optional.NewString(generateID()),
 		XRequestId:      optional.NewString(requestId),
 	})
-	if err != nil {
-		return cust, fmt.Errorf("problem creating customer: %v", err)
-	}
 	if resp != nil {
 		resp.Body.Close()
+	}
+	if err != nil {
+		return cust, fmt.Errorf("problem creating customer: %v", err)
 	}
 	return cust, nil
 }
@@ -138,22 +138,22 @@ func createTransfer(ctx context.Context, api *moov.APIClient, cust moov.Customer
 		XIdempotencyKey: optional.NewString(generateID()),
 		XRequestId:      optional.NewString(requestId),
 	})
-	if err != nil {
-		return tx, fmt.Errorf("problem creating transfer: %v", err)
-	}
 	if resp != nil {
 		resp.Body.Close()
+	}
+	if err != nil {
+		return tx, fmt.Errorf("problem creating transfer: %v", err)
 	}
 	if !*flagFakeData {
 		// Delete the transfer (and underlying file) since we're only making one Transfer
 		resp, err = api.TransfersApi.DeleteTransferByID(ctx, tx.Id, &moov.DeleteTransferByIDOpts{
 			XRequestId: optional.NewString(requestId),
 		})
-		if err != nil {
-			return tx, fmt.Errorf("problem deleting transfer: %v", err)
-		}
 		if resp != nil {
 			resp.Body.Close()
+		}
+		if err != nil {
+			return tx, fmt.Errorf("problem deleting transfer: %v", err)
 		}
 	}
 	return tx, nil


### PR DESCRIPTION
I noticed these would be left unclosed if the error conditions were matched on, which seems to happen with `-fake-data` enabled. 