### PR TITLE
cmd/apitest: add logic for verifying paygate merged files after fake transfer generation

### DIFF
--- a/cmd/apitest/main.go
+++ b/cmd/apitest/main.go
@@ -48,6 +48,9 @@ var (
 
 	flagFakeData       = flag.Bool("fake-data", false, "Generate fake data (instead of one transfer) across several routing numbers, customers, and originators")
 	flagFakeIterations = flag.Int("fake-data.iterations", 1000, "How many users and transfers to create")
+
+	flagVerifyTransfers    = flag.String("verify-transfers.dir", "", "Verify the created transfers exist in the given directory of ACH files")
+	flagVerifyInitialSleep = flag.Duration("verify-transfers.initial-sleep", 1*time.Minute, "Duration to sleep so paygate can process and merge all transfers")
 )
 
 func main() {
@@ -63,6 +66,14 @@ func main() {
 		log.Fatalf("FAILURE: %v", err)
 	}
 
+	// If we're going to verify we need the directory to be empty beforehand
+	if *flagVerifyTransfers != "" && !verifyDirIsEmpty(*flagVerifyTransfers) {
+		log.Fatalf("FAILURE: verify directory %s is not empty", *flagVerifyTransfers)
+	}
+
+	var mu sync.Mutex
+	var iterations []*iteration
+
 	// Run either one or many iterations
 	if *flagFakeData {
 		fmt.Println("") // add buffer space in output
@@ -73,14 +84,29 @@ func main() {
 			wg.Add(1)
 			gate.Start()
 			go func() {
-				iterate(ctx)
+				if iter := iterate(ctx); iter != nil {
+					mu.Lock()
+					iterations = append(iterations, iter)
+					mu.Unlock()
+				}
 				gate.Done()
 				wg.Done()
 			}()
 		}
 		wg.Wait()
 	} else {
-		iterate(ctx) // just one user and transfer
+		if iter := iterate(ctx); iter != nil {
+			iterations = append(iterations, iter) // just one user and transfer
+		}
+	}
+
+	// Verify every transfer we made exists
+	if *flagVerifyTransfers != "" {
+		log.Printf("Sleeping for %v to let paygate collect and merge transfers", flagVerifyInitialSleep)
+		time.Sleep(*flagVerifyInitialSleep)
+		if err := verifyTransfersWereMerged(*flagVerifyTransfers, iterations); err != nil {
+			log.Fatalf("FAILURE: %v", err)
+		}
 	}
 }
 
@@ -217,6 +243,7 @@ func iterate(ctx context.Context) *iteration {
 	user, err := createUser(ctx, api, requestId)
 	if err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	debugLogger("SUCCESS: Created user %s (email: %s)", user.ID, user.Email)
 
@@ -226,12 +253,14 @@ func iterate(ctx context.Context) *iteration {
 	// Verify Cookie works
 	if err := verifyUserIsLoggedIn(ctx, api, user, requestId); err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	debugLogger("SUCCESS: Cookie works for user %s", user.ID)
 
 	oauthToken, err := createOAuthToken(ctx, api, user, requestId)
 	if err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	expiresIn, _ := time.ParseDuration(fmt.Sprintf("%ds", oauthToken.ExpiresIn))
 	if v := os.Getenv("TRAVIS_OS_NAME"); v != "" {
@@ -255,12 +284,14 @@ func iterate(ctx context.Context) *iteration {
 	origAcct, err := createGLAccount(ctx, glClient, user, "from account", requestId) // TODO(adam): need to add balance, paygate will check
 	if err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 
 	// Create Originator Depository
 	origDep, err := createDepository(ctx, api, user, origAcct, requestId)
 	if err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	debugLogger("SUCCESS: Created Originator Depository (id=%s) for user", origDep.Id)
 
@@ -268,6 +299,7 @@ func iterate(ctx context.Context) *iteration {
 	orig, err := createOriginator(ctx, api, origDep.Id, requestId)
 	if err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	debugLogger("SUCCESS: Created Originator (id=%s) for user", orig.Id)
 
@@ -275,12 +307,14 @@ func iterate(ctx context.Context) *iteration {
 	custAcct, err := createGLAccount(ctx, glClient, user, "to account", requestId)
 	if err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 
 	// Create Customer Depository
 	custDep, err := createDepository(ctx, api, user, custAcct, requestId)
 	if err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	debugLogger("SUCCESS: Created Customer Depository (id=%s) for user", custDep.Id)
 
@@ -288,6 +322,7 @@ func iterate(ctx context.Context) *iteration {
 	cust, err := createCustomer(ctx, api, user, custDep.Id, requestId)
 	if err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	debugLogger("SUCCESS: Created Customer (id=%s) for user", cust.Id)
 
@@ -295,18 +330,21 @@ func iterate(ctx context.Context) *iteration {
 	tx, err := createTransfer(ctx, api, cust, orig, amount(), requestId)
 	if err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	debugLogger("SUCCESS: Created %s transfer (id=%s) for user", tx.Amount, tx.Id)
 
 	// Attempt a Failed login
 	if err := attemptFailedLogin(ctx, api, requestId); err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	debugLogger("SUCCESS: invalid login credentials were rejected")
 
 	// Attempt a Failed OAuth2 auth check
 	if err := attemptFailedOAuth2Login(ctx, api, requestId); err != nil {
 		errLogger("FAILURE: %v", err)
+		return nil
 	}
 	debugLogger("SUCCESS: invalid OAuth2 access token was rejected")
 

--- a/cmd/apitest/verify.go
+++ b/cmd/apitest/verify.go
@@ -1,0 +1,111 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/moov-io/ach"
+)
+
+func verifyDirIsEmpty(dir string) bool {
+	s, err := os.Stat(dir)
+	if err != nil || !s.IsDir() {
+		if os.IsNotExist(err) {
+			return true // dir doesn't exist
+		}
+		return false // dir doesnisn't a directory
+	}
+	fd, err := os.Open(dir)
+	if err != nil {
+		return false
+	}
+	names, err := fd.Readdirnames(1)
+	if (err != nil && err != io.EOF) || len(names) > 0 {
+		return false // found a file, so not empty
+	}
+	return true
+}
+
+// verifyTransfersWereMerged will take the incoming iterations (i.e. Transfers and related metadata) to
+// verify all transfers exist in the merged ACH files in dir. This is done to help ensure paygate handles
+// and uploads all the given transfers to the FED / receiving FI.
+func verifyTransfersWereMerged(dir string, iterations []*iteration) error {
+	if len(iterations) == 0 {
+		return fmt.Errorf("no iterations (transfers) found")
+	}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if (err != nil && err != filepath.SkipDir) || info.IsDir() {
+			return nil // Ignore SkipDir and directories
+		}
+
+		file, err := parseACHFilepath(path)
+		if err != nil {
+			return fmt.Errorf("error reading %s: %v", path, err)
+		}
+		i := -1
+		for {
+			i++
+			if i >= len(iterations) {
+				break
+			}
+			if file.Header.ImmediateOrigin != iterations[i].originatorDepository.RoutingNumber {
+				continue
+			}
+			if file.Header.ImmediateDestination != iterations[i].customerDepository.RoutingNumber {
+				continue
+			}
+			// Check file's batches
+			for j := range file.Batches {
+				entries := file.Batches[j].GetEntries()
+				for k := range entries {
+					// TODO(adam): Once/If we move paygate's Amount into a shared lib we can do a better comparison here
+					if iterations[i].transfer.Amount == fmt.Sprintf("USD %.2f", float64(entries[k].Amount)/100.0) {
+						log.Printf("INFO: Matched transfer %s for %s", iterations[i].transfer.Id, iterations[i].transfer.Amount)
+						// found a match // TODO(adam): compare more fields?
+						iterations = append(iterations[:i], iterations[i+1:]...) // remove iteration
+						i = -1                                                   // reset i so we reprocess entire iterations array
+						goto next
+					}
+				}
+			}
+		next:
+			// check the next iteration, iterations leftover are those that weren't found in a file
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(iterations) > 0 {
+		var transferLine []string
+		for i := range iterations {
+			transferLine = append(transferLine, fmt.Sprintf("%s (amount: %s)", iterations[i].transfer.Id, iterations[i].transfer.Amount))
+		}
+		return fmt.Errorf("transfers not matched!!\n%s", strings.Join(transferLine, "\n"))
+	} else {
+		log.Printf("SUCCESS: all transfers matched in merged file(s)")
+	}
+	return nil
+}
+
+func parseACHFilepath(path string) (*ach.File, error) {
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	file, err := ach.NewReader(fd).Read()
+	if err != nil {
+		return nil, err
+	}
+	return &file, nil
+}

--- a/cmd/apitest/verify_test.go
+++ b/cmd/apitest/verify_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerify_verifyDirIsEmpty(t *testing.T) {
+	dir, err := ioutil.TempDir("", "verifyDirIsEmpty")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !verifyDirIsEmpty(dir) {
+		t.Error("empty dir should be empty")
+	}
+
+	// write a file and verify the dir is non-empty
+	fd, err := os.Create(filepath.Join(dir, "file.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = io.Copy(fd, strings.NewReader("hello, world")); err != nil {
+		t.Fatal(err)
+	}
+	fd.Sync()
+	fd.Close()
+
+	// won't be empty
+	if verifyDirIsEmpty(dir) {
+		t.Error("dir should be empty")
+	}
+
+	// delete that file and retry
+	if err := os.Remove(filepath.Join(dir, "file.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if !verifyDirIsEmpty(dir) {
+		t.Error("empty dir should be empty")
+	}
+}


### PR DESCRIPTION

As part of paygate's work to merge transfers for more efficient ACH
uploads to the Fed we need to verify the files contain exactly the
transfers which have been created.

See: https://github.com/moov-io/paygate/pull/96