### PR TITLE
cmd/apitest: switch back to go-client for GL requests

### DIFF
--- a/cmd/apitest/local/transport.go
+++ b/cmd/apitest/local/transport.go
@@ -62,6 +62,8 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 	case "fed":
 		r.URL.Host += bind.HTTP("fed")
 		r.URL.Path = "/fed/" // fed expects /fed/ as a prefix on routes
+	case "gl":
+		r.URL.Host += bind.HTTP("gl")
 	case "paygate":
 		r.URL.Host += bind.HTTP("paygate")
 	case "oauth2":

--- a/cmd/apitest/main.go
+++ b/cmd/apitest/main.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/moov-io/api/cmd/apitest/local"
 	"github.com/moov-io/api/internal/version"
-	gl "github.com/moov-io/gl/client"
 	moov "github.com/moov-io/go-client/client"
 
 	"github.com/antihax/optional"
@@ -170,11 +169,11 @@ type iteration struct {
 	oauthToken moov.OAuth2Token
 
 	originator           moov.Originator
-	originatorAccount    *gl.Account
+	originatorAccount    *moov.Account
 	originatorDepository moov.Depository
 
 	customer           moov.Customer
-	customerAccount    *gl.Account
+	customerAccount    *moov.Account
 	customerDepository moov.Depository
 
 	transfer moov.Transfer
@@ -247,12 +246,10 @@ func iterate(ctx context.Context) *iteration {
 		setMoovOAuthToken(conf, oauthToken)
 	}
 
-	glClient := setupGLClient(user)
-
 	// Create Originator GL account
 	// This is only needed because our GL setup (for apitest's default environment) doesn't have
 	// accounts backing it. We create on in our GL service for each test run.
-	origAcct, err := createGLAccount(ctx, glClient, user, "from account", requestId) // TODO(adam): need to add balance, paygate will check
+	origAcct, err := createGLAccount(ctx, api, user, "from account", requestId) // TODO(adam): need to add balance, paygate will check
 	if err != nil {
 		errLogger("FAILURE: %v", err)
 	}
@@ -272,7 +269,7 @@ func iterate(ctx context.Context) *iteration {
 	debugLogger("SUCCESS: Created Originator (id=%s) for user", orig.Id)
 
 	// Create Customer GL account
-	custAcct, err := createGLAccount(ctx, glClient, user, "to account", requestId)
+	custAcct, err := createGLAccount(ctx, api, user, "to account", requestId)
 	if err != nil {
 		errLogger("FAILURE: %v", err)
 	}

--- a/cmd/apitest/transfer.go
+++ b/cmd/apitest/transfer.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	gl "github.com/moov-io/gl/client"
 	moov "github.com/moov-io/go-client/client"
 
 	"github.com/antihax/optional"
@@ -24,7 +23,7 @@ type fiInfo struct {
 
 // TODO(adam): on -fake-data we need to randomize all data, but keep the existing values on single Transfer creations
 
-func createDepository(ctx context.Context, api *moov.APIClient, u *user, account *gl.Account, requestId string) (moov.Depository, error) {
+func createDepository(ctx context.Context, api *moov.APIClient, u *user, account *moov.Account, requestId string) (moov.Depository, error) {
 	req := moov.CreateDepository{
 		BankName:      "Moov Bank",
 		AccountNumber: account.AccountNumber,


### PR DESCRIPTION
Now that go-client can be generated again let's drop our usage of gl's client as we had to duplicate init logic for it.

Related: https://github.com/moov-io/api/issues/81 